### PR TITLE
Show start texts during username entry

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -263,11 +263,11 @@ function draw(){
     if(!gameStarted){
         ctx.fillStyle = 'white';
         ctx.font = '48px sans-serif';
-        const title = 'Свадьба Ксю и Дани';
+        const title = 'Свадьба Ксюши и Дани';
         const titleW = ctx.measureText(title).width;
         ctx.fillText(title, (width-titleW)/2, height/2 - 60);
         ctx.font = '32px sans-serif';
-        const prompt = 'Нажми большой Enter для начала игры';
+        const prompt = 'Нажми большой Enter для начала';
         const pW = ctx.measureText(prompt).width;
         ctx.fillText(prompt,(width-pW)/2, height/2);
         return;

--- a/web/index.html
+++ b/web/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Свадьба Ксю и Дани</title>
+    <title>Свадьба Ксюши и Дани</title>
     <style>
         html, body { margin:0; padding:0; overflow:hidden; }
         canvas { display:block; background:#000; }
@@ -21,6 +21,16 @@
             background:rgba(0,0,0,0.8);
             color:#fff;
             z-index:10;
+            text-align:center;
+            font-family:'CCRFBZSR', sans-serif;
+        }
+        #usernameOverlay h1{
+            margin-bottom:20px;
+            font-size:48px;
+        }
+        #usernameOverlay p{
+            margin-bottom:20px;
+            font-size:24px;
         }
         #scoreboard {
             position:absolute;
@@ -39,6 +49,8 @@
 </head>
 <body>
     <div id="usernameOverlay">
+        <h1>Свадьба Ксюши и Дани</h1>
+        <p>Нажми большой Enter для начала</p>
         <div>
             <input id="usernameInput" placeholder="Введи имя">
             <button id="startButton">Начать</button>


### PR DESCRIPTION
## Summary
- display the welcome messages inside the username overlay
- update text to "Свадьба Ксюши и Дани" and modify prompt
- style overlay heading and prompt

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6862d6a3ede88328856b710b9f0fc58e