### PR TITLE
Fix unintended jump when entering name

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -93,6 +93,8 @@ usernameInput.addEventListener('keydown', (e) => {
             usernameOverlay.style.display = 'none';
             startGame();
         }
+        // Prevent the event from bubbling to the global listener
+        e.stopPropagation();
     }
 });
 
@@ -347,6 +349,8 @@ function gameLoop(){
 
 // Events
 window.addEventListener('keydown', e=>{
+    // Ignore global key events when the username overlay is visible
+    if (usernameOverlay.style.display !== 'none') return;
     if(e.code==='Space' || e.code==='Enter'){
         if(!gameStarted) {
             startGame();


### PR DESCRIPTION
## Summary
- prevent keydown events from the name field from bubbling
- ignore global keypresses while the username prompt is visible

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862fd9174488328bd72fbf7d6a98756