### PR TITLE
Hide tutorial hints on game over

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -263,6 +263,7 @@ function update(){
     obstacles.forEach(o=>{
         if(intersects(player.rect(), o.rect())){
             isGameOver = true;
+            tutorialMessages.length = 0; // hide tutorial hints on game over
         }
     });
     bonuses.forEach((b,i)=>{


### PR DESCRIPTION
## Summary
- reset tutorial message array when the player loses so hints disappear

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6872b6df815c832889f8739fc1477f0e