### PR TITLE
Add looping background music

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -8,6 +8,20 @@ canvas.height = height;
 
 const assetsPath = 'assets/';
 
+// Background music
+const backgroundMusic = new Audio('music/track1.MP3');
+backgroundMusic.loop = true;
+backgroundMusic.addEventListener('ended', () => {
+    backgroundMusic.currentTime = 0;
+    backgroundMusic.play().catch(()=>{});
+});
+
+function startBackgroundMusic(){
+    backgroundMusic.currentTime = 0;
+    backgroundMusic.play().catch(()=>{});
+}
+document.addEventListener('keydown', startBackgroundMusic, {once:true});
+
 // Images
 const images = {
     background: loadImage('background.png'),

--- a/web/service-worker.js
+++ b/web/service-worker.js
@@ -13,6 +13,7 @@ const urlsToCache = [
   'assets/bonus_3.png',
   'assets/bonus_4.png',
   'assets/ic_star.webp'
+  , 'music/track1.MP3'
 ];
 
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- add music file to service worker cache
- play track1.MP3 on first key press and loop it

## Testing
- `node -c web/game.js`
- `node -c web/service-worker.js`


------
https://chatgpt.com/codex/tasks/task_e_6872d4a3d92c8328824e1344147e8d01