### PR TITLE
Add start screen on Tab during pause

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -383,7 +383,7 @@ window.addEventListener('keydown', e=>{
         }
     } else if(isGameOver && (e.code==='ShiftLeft' || e.code==='ShiftRight')){
         startGame();
-    } else if(isGameOver && e.code==='Tab'){
+    } else if((!gameStarted || isGameOver) && e.code==='Tab'){
         e.preventDefault();
         currentUser='';
         usernameOverlay.style.display='flex';


### PR DESCRIPTION
## Summary
- display username overlay when pressing Tab if game is not running

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872d76490108328b0ac4721ee8070ac