### PR TITLE
Fix scoreboard state after pressing Tab

### DIFF
--- a/web/game.js
+++ b/web/game.js
@@ -388,6 +388,8 @@ window.addEventListener('keydown', e=>{
         currentUser='';
         usernameOverlay.style.display='flex';
         gameStarted=false;
+        isGameOver=false;
+        updateScoreboard();
     }
 });
 


### PR DESCRIPTION
## Summary
- allow exiting game over screen with Tab

## Testing
- `node -c web/game.js`

------
https://chatgpt.com/codex/tasks/task_e_6873c6fb6e488328b0b86526f983d65a